### PR TITLE
Update the external links of code of conduct references

### DIFF
--- a/CODE-OF-CONDUCT-EN.md
+++ b/CODE-OF-CONDUCT-EN.md
@@ -12,7 +12,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 --- 
 
-This work is based on [Droidcon NYC Code of Conduct](http://droidcon.nyc/code-of-conduct/) and [DroidKaigi Code of Conduct](http://www.association.droidkaigi.jp/en/code-of-conduct.html) which are licensed under CC-BY-3.0.
+This work is based on [Droidcon NYC Code of Conduct](https://nyc.droidcon.com/code-of-conduct/) and [DroidKaigi Code of Conduct](https://portal.droidkaigi.jp/en/about/code-of-conduct) which are licensed under CC-BY-3.0.
 
 This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US).
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -27,7 +27,7 @@ KotlinFestに参加するすべての人は下記の行動規範を守ること�
 
 ---
 
-この行動規範は、CC-BY-3.0で公開されている[Droidcon NYCのCode of Conduct](http://droidcon.nyc/code-of-conduct/)および、[DroidKaigiのCode of Conduct](http://www.association.droidkaigi.jp/code-of-conduct.html)を元に作成しています。
+この行動規範は、CC-BY-3.0で公開されている[Droidcon NYCのCode of Conduct](https://nyc.droidcon.com/code-of-conduct/)および、[DroidKaigiのCode of Conduct](https://portal.droidkaigi.jp/about/code-of-conduct)を元に作成しています。
 
 This work is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/deed.en_US).
 


### PR DESCRIPTION
The following links of code of conduct references look outdated
- http://droidcon.nyc/code-of-conduct/
- http://www.association.droidkaigi.jp/en/code-of-conduct.html
- http://www.association.droidkaigi.jp/code-of-conduct.html

This PR replaces the links above with the followings, respectively.
- https://nyc.droidcon.com/code-of-conduct/
- https://portal.droidkaigi.jp/en/about/code-of-conduct
- https://portal.droidkaigi.jp/about/code-of-conduct